### PR TITLE
Add minimal Next.js blog with furigana support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# test-chatgpt-codex
+# Furigana Blog
+
+This is a minimal Next.js blog that demonstrates how to display Japanese text with furigana using HTML `<ruby>` tags.
+
+## Development
+
+1. Install dependencies (requires Node.js):
+
+```bash
+npm install
+```
+
+2. Start the development server:
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:3000` in your browser to view the blog.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "furigana-blog",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.10",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,3 @@
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import { posts } from '../posts/posts';
+
+export default function Home() {
+  return (
+    <div style={{ fontFamily: 'sans-serif', padding: '20px' }}>
+      <h1>Furigana Blog</h1>
+      <ul>
+        {posts.map(post => (
+          <li key={post.slug}>
+            <Link href={`/posts/${post.slug}`}>{post.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { posts } from '../../posts/posts';
+
+export default function Post() {
+  const router = useRouter();
+  const { slug } = router.query;
+  const post = posts.find(p => p.slug === slug);
+
+  if (!post) return <p>Post not found</p>;
+
+  return (
+    <div style={{ fontFamily: 'sans-serif', padding: '20px' }}>
+      <h1>{post.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.content }} />
+      <p>
+        <Link href='/'>Back to home</Link>
+      </p>
+    </div>
+  );
+}

--- a/posts/posts.js
+++ b/posts/posts.js
@@ -1,0 +1,18 @@
+export const posts = [
+  {
+    slug: 'greeting',
+    title: '挨拶について',
+    content: `\
+      <p><ruby>日本<rt>にほん</rt></ruby>では<ruby>挨拶<rt>あいさつ</rt></ruby>が大切です。</p>
+      <p><ruby>朝<rt>あさ</rt></ruby>は「おはようございます」と<ruby>言<rt>い</rt></ruby>います。</p>
+    `,
+  },
+  {
+    slug: 'culture',
+    title: '文化紹介',
+    content: `\
+      <p><ruby>東京<rt>とうきょう</rt></ruby>は<ruby>日本<rt>にほん</rt></ruby>の<ruby>首都<rt>しゅと</rt></ruby>です。</p>
+      <p><ruby>京都<rt>きょうと</rt></ruby>には<ruby>多<rt>おお</rt></ruby>くの<ruby>寺<rt>てら</rt></ruby>があります。</p>
+    `,
+  },
+];


### PR DESCRIPTION
## Summary
- initialize simple Next.js project structure
- add sample posts with furigana using `<ruby>` tags
- list posts on the homepage and show content with dynamic routes
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864adccd99083229384cae57e36daa7